### PR TITLE
Cross-build Scala 2.13 and 2.12, remove support 2.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,17 +1,17 @@
 import CompileFlags._
 import Dependencies._
 
+lazy val scala213 = "2.13.1"
 lazy val scala212 = "2.12.10"
-lazy val scala211 = "2.11.12"
-lazy val supportedScalaVersions = List(scala212, scala211)
+lazy val supportedScalaVersions = List(scala213, scala212)
 
-ThisBuild / scalaVersion := scala212
+ThisBuild / scalaVersion := scala213
 ThisBuild / organization := "com.colisweb"
 ThisBuild / organizationName := "colisweb"
 ThisBuild / bintrayOrganization := Some("colisweb")
 ThisBuild / licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
 ThisBuild / parallelExecution := false
-ThisBuild / scalacOptions ++= flags
+ThisBuild / scalacOptions ++= crossScalacOptions(scalaVersion.value)
 
 resolvers += Resolver.sonatypeRepo("releases")
 
@@ -36,11 +36,12 @@ lazy val context = Project(id = "scala-opentracing-context", base = file("contex
     crossScalaVersions := supportedScalaVersions,
     libraryDependencies ++= OpenTracing.all
       ++ Seq(
+        scalaCollectionsCompat,
         TestsDependencies.scalatest,
         Cats.cats,
         Cats.catsEffect,
         Http4s.http4sDsl,
-        compilerPlugin(kindProjector)
+        compilerPlugin(kindProjector),
       )
   )
 
@@ -66,6 +67,7 @@ lazy val httpTest = Project(id = "scala-opentracing-http4s-test", base = file("h
   .dependsOn(httpClient, httpServer)
   .settings(
     libraryDependencies ++= TestsDependencies.utils ++ TestsDependencies.circeAll,
-    scalacOptions ++= Seq("-Ypartial-unification"),
     skip in publish := true
   )
+
+

--- a/context/src/main/scala/com/colisweb/tracing/context/datadog/DDTracingContext.scala
+++ b/context/src/main/scala/com/colisweb/tracing/context/datadog/DDTracingContext.scala
@@ -15,7 +15,7 @@ import io.opentracing.util.{GlobalTracer => OpenGlobalTracer}
 import net.logstash.logback.marker.Markers.appendEntries
 import org.slf4j.{Logger, Marker}
 
-import scala.collection.JavaConverters.mapAsJavaMap
+import scala.jdk.CollectionConverters._
 
 /**
   * This tracing context is intended to be used with Datadog APM.
@@ -63,7 +63,7 @@ class DDTracingContext[F[_]: Sync](
       spanId <- spanIdMarker
       traceId <- traceIdMarker
     } yield appendEntries(
-      mapAsJavaMap(traceId ++ spanId)
+      (traceId ++ spanId).asJava
     )
 
   }

--- a/core/src/main/scala/com/colisweb/tracing/core/PureLogger.scala
+++ b/core/src/main/scala/com/colisweb/tracing/core/PureLogger.scala
@@ -31,8 +31,6 @@ trait PureLogger[F[_]] {
 
 object PureLogger {
 
-  type LoggingFunction[F[_]] = (Option[Marker], String, Object*) => F[Unit]
-
   def apply[F[_]: Sync](logger: org.slf4j.Logger): PureLogger[F] =
     new PureLogger[F] {
 

--- a/project/CompileFlags.scala
+++ b/project/CompileFlags.scala
@@ -1,3 +1,5 @@
+import sbt.librarymanagement.CrossVersion
+
 object CompileFlags {
   val flags = Seq(
     "-deprecation", // Emit warning and location for usages of deprecated APIs.
@@ -13,9 +15,7 @@ object CompileFlags {
     "-unchecked", // Enable additional warnings where generated code depends on assumptions.
     "-Xcheckinit", // Wrap field accessors to throw an exception on uninitialized access.
     "-Xfatal-warnings", // Fail the compilation if there are any warnings.
-    "-Xfuture", // Turn on future language features.
     "-Xlint:adapted-args", // Warn if an argument list is modified to match the receiver.
-    "-Xlint:by-name-right-associative", // By-name parameter of right associative operator.
     "-Xlint:constant", // Evaluation of a constant arithmetic expression results in an error.
     "-Xlint:delayedinit-select", // Selecting member of DelayedInit.
     "-Xlint:doc-detached", // A Scaladoc comment appears to be detached from its element.
@@ -29,15 +29,8 @@ object CompileFlags {
     "-Xlint:private-shadow", // A private field (or class parameter) shadows a superclass field.
     "-Xlint:stars-align", // Pattern sequence wildcard must align with sequence component.
     "-Xlint:type-parameter-shadow", // A local type parameter shadows a type already in scope.
-    "-Xlint:unsound-match", // Pattern match may not be typesafe.
-    "-Yno-adapted-args", // Do not adapt an argument list (either by inserting () or creating a tuple) to match the receiver.
-    "-Ypartial-unification", // Enable partial unification in type constructor inference
     "-Ywarn-dead-code", // Warn when dead code is identified.
     "-Ywarn-extra-implicit", // Warn when more than one implicit parameter section is defined.
-    "-Ywarn-inaccessible", // Warn about inaccessible types in method signatures.
-    "-Ywarn-infer-any", // Warn when a type argument is inferred to be `Any`.
-    "-Ywarn-nullary-override", // Warn when non-nullary `def f()' overrides nullary `def f'.
-    "-Ywarn-nullary-unit", // Warn when nullary methods return Unit.
     "-Ywarn-numeric-widen", // Warn when numerics are widened.
     "-Ywarn-unused:implicits", // Warn if an implicit parameter is unused.
     "-Ywarn-unused:imports", // Warn if an import selector is not referenced.
@@ -45,6 +38,32 @@ object CompileFlags {
     "-Ywarn-unused:params", // Warn if a value parameter is unused.
     "-Ywarn-unused:patvars", // Warn if a variable bound in a pattern is unused.
     "-Ywarn-unused:privates", // Warn if a private member is unused.
-    "-Ywarn-value-discard", // Warn when non-Unit expression results are unused.
+    "-Ywarn-value-discard" // Warn when non-Unit expression results are unused.
   )
+
+  val flags212 = Seq(
+    "-Xfuture", // Turn on future language features.
+    "-Yno-adapted-args", // Do not adapt an argument list (either by inserting () or creating a tuple) to match the receiver.
+    "-Xlint:by-name-right-associative", // By-name parameter of right associative operator.
+    "-Xlint:unsound-match", // Pattern match may not be typesafe.
+    "-Ypartial-unification", // Enable partial unification in type constructor inference
+    "-Ywarn-inaccessible", // Warn about inaccessible types in method signatures.
+    "-Ywarn-infer-any", // Warn when a type argument is inferred to be `Any`.
+    "-Ywarn-nullary-override", // Warn when non-nullary `def f()' overrides nullary `def f'.
+    "-Ywarn-nullary-unit" // Warn when nullary methods return Unit.
+  )
+
+  val flags213 = Seq(
+    "-Xlint:adapted-args", // Warn if an argument list is modified to match the receiver.
+    "-Xlint:inaccessible",
+    "-Xlint:infer-any",
+    "-Xlint:nullary-override"
+  )
+
+  def crossScalacOptions(version: String): Seq[String] =
+    CrossVersion.partialVersion(version) match {
+      case Some((2L, 13L)) => flags ++ flags213
+      case Some((2L, 12L)) => flags ++ flags212
+      case _               => Seq.empty
+    }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,8 @@ import sbt._
 
 object Dependencies {
   final val fs2Rabbit = "dev.profunktor" %% "fs2-rabbit" % "2.1.1"
-  final val kindProjector = "org.typelevel" %% "kind-projector" % "0.10.3"
+  final val kindProjector = "org.typelevel" %% "kind-projector" % "0.11.0" cross CrossVersion.full
+  final val scalaCollectionsCompat = "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.4"
 
   object Cats {
     final val cats = "org.typelevel" %% "cats-core" % "2.0.0"
@@ -29,7 +30,7 @@ object Dependencies {
 
     final val blazeClient = "org.http4s" %% "http4s-blaze-client" % version
     final val core = "org.http4s" %% "http4s-core" % version
-    final val http4sDsl = "org.http4s" %% "http4s-dsl" % "0.20.21"
+    final val http4sDsl = "org.http4s" %% "http4s-dsl" % version
 
     final val all = List(blazeClient, core)
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
 addSbtPlugin("org.foundweekends"         % "sbt-bintray"   % "0.5.6")
 addSbtPlugin("org.scalameta"             % "sbt-scalafmt"  % "2.3.4")
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat"  % "0.1.8")
+addSbtPlugin("ch.epfl.scala"             % "sbt-scalafix"  % "0.9.8")
+


### PR DESCRIPTION
Motivation:

Use the library in Scala 2.13 project.

Modification:

- Extract compiler flags
- Remove Scala 2.11 support, because HTTP4s DSL is not published for 2.11
anymore.
- Add Scala Collections Compat to cross-compile for 2.13 and 2.12.

Result:

in sbt both pass:

```
> + compile
> + test
```

Thank you!